### PR TITLE
Fix/sensitive vendor vars

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,20 @@
 locals {
+  vendors = {
+    "GOOGLE_CREDENTIALS"    = var.GOOGLE_CREDENTIALS
+    "AWS_SECRET_ACCESS_KEY" = var.AWS_SECRET_ACCESS_KEY
+    "AWS_SECRET_KEY_ID"     = var.AWS_SECRET_KEY_ID
+  }
+
+  vendor_sensitive = flatten([
+    for wk, workspace in var.workspaces : [
+      for item in workspace.vendors_vars : {
+        workspace_name = wk
+        var_key        = item
+        var_value      = lookup(local.vendors, item)
+      }
+    ]
+  ])
+
   env_vars = flatten([
     for wk, workspace in var.workspaces : [
       for var_key, var_value in workspace.env_vars : {

--- a/tfc_variables.tf
+++ b/tfc_variables.tf
@@ -31,3 +31,12 @@ resource "tfe_variable" "environment_variable" {
   category     = "env"
   workspace_id = tfe_workspace.this[each.value.workspace_name].id
 }
+
+resource "tfe_variable" "vendors_secrets" {
+  for_each     = { for v in local.vendor_sensitive : "${v.workspace_name}.${v.var_key}" => v }
+  key          = each.value.var_key
+  value        = each.value.var_value
+  category     = "env"
+  sensitive    = true
+  workspace_id = tfe_workspace.this[each.value.workspace_name].id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -17,6 +17,7 @@ variable "workspaces" {
     terraform_vars            = map(string)
     sensitive_env_vars        = list(string)
     sensitive_terraform_vars  = list(string)
+    vendors_vars              = map(string)
   }))
 }
 
@@ -38,4 +39,22 @@ variable "terraform_cloud_workspace_name" {
 variable "terraform_cloud_token" {
   description = "The Team token used to authenticate with Terraform Cloud. See [Authentication](https://registry.terraform.io/providers/hashicorp/tfe/latest/docs#authentication) for more information"
   type        = string
+}
+
+variable "AWS_SECRET_ACCESS_KEY" {
+  description = "AWS secret access key"
+  type        = string
+  default     = ""
+}
+
+variable "AWS_SECRET_KEY_ID" {
+  description = "AWS secret key id"
+  type        = string
+  default     = ""
+}
+
+variable "GOOGLE_CREDENTIALS" {
+  description = "GCP Credentials"
+  type        = string
+  default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -17,7 +17,7 @@ variable "workspaces" {
     terraform_vars            = map(string)
     sensitive_env_vars        = list(string)
     sensitive_terraform_vars  = list(string)
-    vendors_vars              = map(string)
+    vendors_vars              = list(string)
   }))
 }
 


### PR DESCRIPTION
This is a hotfix, we would need to refactor this code later.

For now, it is hardcoded common authentication secrets to GCP and AWS vendors, like GOOGLE_CREDENTIALS and AWS_SECRET_KEY_ID and AWS_SECRET_ACCESS_KEY.

It will create only the necessary key based on what variables are created manually in bootstrap workspace on terraform cloud