### PR TITLE
testing new approach

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,20 +1,4 @@
 locals {
-  vendors = {
-    "GOOGLE_CREDENTIALS"    = tostring(try(var.GOOGLE_CREDENTIALS, null))
-    "AWS_SECRET_ACCESS_KEY" = tostring(try(var.AWS_SECRET_ACCESS_KEY, null))
-    "AWS_SECRET_KEY_ID"     = tostring(try(var.AWS_SECRET_KEY_ID, null))
-  }
-
-  vendor_sensitive = flatten([
-    for wk, workspace in var.workspaces : [
-      for item in workspace.vendors_vars : {
-        workspace_name = wk
-        var_key        = item
-        var_value      = lookup(local.vendors, item)
-      }
-    ]
-  ])
-
   env_vars = flatten([
     for wk, workspace in var.workspaces : [
       for var_key, var_value in workspace.env_vars : {

--- a/tfc_variables.tf
+++ b/tfc_variables.tf
@@ -31,12 +31,3 @@ resource "tfe_variable" "environment_variable" {
   category     = "env"
   workspace_id = tfe_workspace.this[each.value.workspace_name].id
 }
-
-resource "tfe_variable" "vendors_secrets" {
-  for_each     = { for v in local.vendor_sensitive : "${v.workspace_name}.${v.var_key}" => v }
-  key          = each.value.var_key
-  value        = each.value.var_value
-  category     = "env"
-  sensitive    = true
-  workspace_id = tfe_workspace.this[each.value.workspace_name].id
-}


### PR DESCRIPTION
This PR cleans the code added in the last published version. The best bet, for now, is to move the creation of "vendor vars" out of this module and use the bootstrap project to create them. An example-infrastructure project has a working structure.  